### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,13 @@
 
 - Un rectangle doit être définie en fond de carte qui couvre toute la platforme, plus une marge de 10nm de chaque coté. La couleur de cette zone est COLOR_GrasSurface4
 - Les pistes doivent être définies en polygones à part, couleur COLOR_RunwayConcrete
-- Les taxiways doivent être définies en polygones à part, couleur COLOR_HardSurface1
-- Les aprons doivent être définis en polygones à part, couleur COLOR_HardSurface2
+- Les taxiways doivent être définies en polygones à part, couleur COLOR_HardSurface2
+- Les aprons doivent être définis en polygones à part, couleur COLOR_HardSurface3
 - Les zones d'herbes doivent être définies en polygones à part, couleur COLOR_GrasSurface
 - Les batiments doivent être définis en polygones à part, couleur COLOR_Building
+- Les points d'attente CAT I doivent être définis en polygones à part, couleur COLOR_ProhibitedArea
+- Les points d'attente CAT III doivent être définis en polygones à part, couleur COLOR_TaxiwayOrange
+- Les zones désafectées doivent être définies en polygones à part, couleur COLOR_HardSurface4
+- Les zones chevrons doivent être définis en polygones à part, couleur COLOR_HardSurface4
+- Les lignes médianes des portes et parkings doivent être définis en 'paths' (rubrique [GEO]) à part, couleur COLOR_Taxiway
 - Le moins de points possible doit être utilisé, afin de conserver les performances d'EuroScope


### PR DESCRIPTION
- Changed colors for aprons and taxiways, replaced by the colors used for LFPG, LFPO and LFMN, which ensure a better readability of the freetext
- Added colours for CAT I and CAT III holding points
- Added colour for disused aprons/taxiways/runways
- Added colour for chevrons area
- Added colour for gates centerlines